### PR TITLE
adding invalid form info option to test

### DIFF
--- a/spec/features/create_journal_entry_spec.rb
+++ b/spec/features/create_journal_entry_spec.rb
@@ -28,4 +28,13 @@ feature 'user creates journal entry', %{
     expect(page).to have_content('New journal entry created!')
   end
 
+  scenario 'User does not provide required entry information' do
+    sign_in(user)
+    click_link 'New Journal Entry'
+    click_button 'Create Entry'
+    expect(page).to have_content('Title can\'t be blank')
+    expect(page).to have_content('Date can\'t be blank')
+  end
+
+
 end

--- a/spec/features/create_journal_entry_spec.rb
+++ b/spec/features/create_journal_entry_spec.rb
@@ -36,5 +36,4 @@ feature 'user creates journal entry', %{
     expect(page).to have_content('Date can\'t be blank')
   end
 
-
 end


### PR DESCRIPTION
The feature test for adding a new journal entry previously did not test for the scenario where the user adds invalid info. Now it does.
