### PR TITLE
default date is now today

### DIFF
--- a/app/views/entries/show.html.erb
+++ b/app/views/entries/show.html.erb
@@ -7,7 +7,7 @@
     <h3 class="title text-center div-bar"><%= @entry.title %></h3>
     <div class="content">
       <div class="journal">
-        <h5><%= "Posted by @#{@user.user_name} on #{@entry.date}, near #{@entry.location.name}"%></h5>
+        <h5><%= "Posted by @#{@user.user_name} on #{@entry.date.strftime("%B %d, %Y")}, near #{@entry.location.name}"%></h5>
         <p><%= @entry.body %></p>
         <% if current_user == @user %>
           <h6>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -8,7 +8,7 @@
           <div id="quick-entry" class="big-button small-6 columns text-center small-centered">
             <%= form_for [current_user, @entry] do |f| %>
               <%= f.hidden_field :title, value: '[Title Placeholder]'  %>
-              <%= f.date_select :date, { :discard_day => true, :discard_month => true, :discard_year => true } %>
+              <%= f.hidden_field :date, value: Date.today %>
               <%= f.hidden_field :latitude, value: 0, id:"entry_latitude"  %>
               <%= f.hidden_field :longitude, value: 0, id:"entry_longitude" %>
               <%= f.submit class:"button alert large", style:"display: none;" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,15 +25,6 @@
 
   <script src="https://maps.googleapis.com/maps/api/js?" + <%=ENV['GOOGLE_MAPS_API_KEY']%>></script>
   <%= javascript_include_tag 'application' %>
-  <script>
-    $(document).ready(function() {
-      setTimeout(function(){
-        $(".alert-box").fadeOut("slow", function() {
-          $(this).remove();
-        })
-      }, 3000);
-    });
-  </script>
   <%= yield :extra_footer %>
 </body>
 </html>

--- a/spec/features/view_a_friends_entries_spec.rb
+++ b/spec/features/view_a_friends_entries_spec.rb
@@ -22,7 +22,7 @@ feature 'view a friends journal entry', %{
     visit user_path(user2)
     click_link entry.title
     expect(page).to have_content(entry.body)
-    expect(page).to have_content(entry.date)
+    expect(page).to have_content(entry.date.strftime("%B %d, %Y"))
     expect(page).to have_content(entry.location.name)
   end
 

--- a/spec/features/view_entry_details_spec.rb
+++ b/spec/features/view_entry_details_spec.rb
@@ -19,7 +19,7 @@ feature 'view journal entry details', %{
     sign_in(user)
     click_link entry.title
     expect(page).to have_content(entry.body)
-    expect(page).to have_content(entry.date)
+    expect(page).to have_content(entry.date.strftime("%B %d, %Y"))
     expect(page).to have_content(entry.location.name)
   end
 


### PR DESCRIPTION
When a user creates a 'Quick Entry', the date defaults to the current date.
